### PR TITLE
Use individual imports instead of `const { a, b, c } = require(...)`

### DIFF
--- a/src/losant/all-equal.js
+++ b/src/losant/all-equal.js
@@ -1,8 +1,14 @@
-const { compose, uniq, length, equals } = require('ramda');
+const compose = require('ramda/src/compose');
+const uniq = require('ramda/src/uniq');
+const length = require('ramda/src/length');
+const equals = require('ramda/src/equals');
 
-// TODO: TESTS
-// TODO: DOCS
-
-// allEqual :: Array -> Boolean
+/**
+ * TODO: TESTS
+ * TODO: DOCS
+ *
+ * @signature Array -> Boolean
+ */
 const allEqual = compose(equals(1), length, uniq);
+
 module.exports = allEqual;

--- a/src/losant/args-to-obj.js
+++ b/src/losant/args-to-obj.js
@@ -1,6 +1,6 @@
-const {
-  pipe, zipObj,
-} = require('ramda');
+const pipe = require('ramda/src/pipe');
+const zipObj = require('ramda/src/zipObj');
+
 const list = require('./list');
 
 /**

--- a/src/losant/clamp-positive.js
+++ b/src/losant/clamp-positive.js
@@ -1,4 +1,4 @@
-const { clamp } = require('ramda');
+const clamp = require('ramda/src/clamp');
 
 /**
  * Clamps a numeric value so that it's guaranteed to be 0 or higher. Works with

--- a/src/losant/contains-all.js
+++ b/src/losant/contains-all.js
@@ -1,17 +1,24 @@
-const {
-  curry, pipe, intersection, length, equals,
-} = require('ramda');
+const curry = require('ramda/src/curry');
+const pipe = require('ramda/src/pipe');
+const intersection = require('ramda/src/intersection');
+const length = require('ramda/src/length');
+const equals = require('ramda/src/equals');
 
-// TODO: TESTS
-// TODO: DOCS
-
-// containsAll :: Array<* a> => Array<* a> -> Boolean
-// EX: containsAll([1, 2, 3], [1, 2, 3, 4, 5])
-const containsAll = curry((smaller, larger) => {
-  return pipe(
+/**
+ * TODO: TESTS
+ * TODO: DOCS
+ *
+ * @signature Array<* a> -> Array<* a> -> Boolean
+ *
+ * @example
+ *     containsAll([1, 2, 3], [1, 2, 3, 4, 5]); // => true
+ */
+const containsAll = curry((smaller, larger) =>
+  pipe(
     intersection(smaller),
     length,
     equals(length(smaller)),
-  )(larger);
-});
+  )(larger)
+);
+
 module.exports = containsAll;

--- a/src/losant/contains-any.js
+++ b/src/losant/contains-any.js
@@ -1,4 +1,6 @@
-const { curry, pipe, intersection } = require('ramda');
+const curry = require('ramda/src/curry');
+const pipe = require('ramda/src/pipe');
+const intersection = require('ramda/src/intersection');
 
 const isNotEmpty = require('./is-not-empty');
 
@@ -6,7 +8,7 @@ const isNotEmpty = require('./is-not-empty');
  * Takes two arrays and returns true if any of the values in the first array
  * are found in the second array.
  *
- * @signature Array -> Array -> Boolean
+ * @signature Array<* a> -> Array<* a> -> Boolean
  */
 const containsAny = curry((needleList, haystackList) =>
   pipe(

--- a/src/losant/count.js
+++ b/src/losant/count.js
@@ -1,4 +1,5 @@
-const { countBy, identity } = require('ramda');
+const countBy = require('ramda/src/countBy');
+const identity = require('ramda/src/identity');
 
 /**
  * `countBy` the raw values in an array (`identity`). All values are

--- a/src/losant/debounce.js
+++ b/src/losant/debounce.js
@@ -1,5 +1,11 @@
-const { compose, curryN } = require('ramda');
-const { flip } = require('lodash/fp');
-const { debounce } = require('lodash');
+const compose = require('ramda/src/compose');
+const curryN = require('ramda/src/curryN');
+const flip = require('lodash/fp/flip');
+const _debounce = require('lodash/debounce');
 
-module.exports = compose(curryN(3), flip)(debounce);
+/**
+ * @signature Object -> Number -> Function -> Function
+ */
+const debounce = compose(curryN(3), flip)(_debounce);
+
+module.exports = debounce;

--- a/src/losant/default-to-strict.js
+++ b/src/losant/default-to-strict.js
@@ -1,16 +1,23 @@
-const {
-  curry, when, either, isNil, complement, always,
-} = require('ramda');
+const curry = require('ramda/src/curry');
+const when = require('ramda/src/when');
+const either = require('ramda/src/either');
+const isNil = require('ramda/src/isNil');
+const complement = require('ramda/src/complement');
+const always = require('ramda/src/always');
+
 const isPopulatedString = require('./is-populated-string');
 
-// TODO: TESTS
-// TODO: DOCS
-
-// defaultToStrict :: * a => * b -> a|b
-const defaultToStrict = curry((def, val) => {
-  return when(
+/**
+ * TODO: TESTS
+ * TODO: DOCS
+ *
+ * @signature * a -> * b -> a|b
+ */
+const defaultToStrict = curry((def, val) =>
+  when(
     either(isNil, complement(isPopulatedString)),
     always(def),
-  )(val);
-});
+  )(val)
+);
+
 module.exports = defaultToStrict;

--- a/src/losant/ensure-array.js
+++ b/src/losant/ensure-array.js
@@ -1,5 +1,5 @@
-const { ifElse } = require('ramda');
-const { isArrayLikeObject } = require('lodash/fp');
+const ifElse = require('ramda/src/ifElse');
+const isArrayLikeObject = require('lodash/fp/isArrayLikeObject');
 
 const list = require('./list');
 

--- a/src/losant/ensure-starts-with.js
+++ b/src/losant/ensure-starts-with.js
@@ -1,6 +1,7 @@
-const {
-  curry, unless, startsWith, concat,
-} = require('ramda');
+const curry = require('ramda/src/curry');
+const unless = require('ramda/src/unless');
+const startsWith = require('ramda/src/startsWith');
+const concat = require('ramda/src/concat');
 
 /**
  * Ensures a string / array value starts with the specified prefix. If not, the

--- a/src/losant/eq-paths.js
+++ b/src/losant/eq-paths.js
@@ -1,4 +1,9 @@
-const { pipe, curry, path, map, apply, equals } = require('ramda');
+const pipe = require('ramda/src/pipe');
+const curry = require('ramda/src/curry');
+const path = require('ramda/src/path');
+const map = require('ramda/src/map');
+const apply = require('ramda/src/apply');
+const equals = require('ramda/src/equals');
 
 /**
  * Takes a path to check and two objects and checks if the value at that path

--- a/src/losant/equals-any.js
+++ b/src/losant/equals-any.js
@@ -1,7 +1,9 @@
-const {
-  flip, contains
-} = require('ramda');
+const flip = require('ramda/src/flip');
+const contains = require('ramda/src/contains');
 
-// equalsAny :: Array<* a> => a -> Boolean
+/**
+ * @signature Array<* a> -> a -> Boolean
+ */
 const equalsAny = flip(contains);
+
 module.exports = equalsAny;

--- a/src/losant/evolve-array.js
+++ b/src/losant/evolve-array.js
@@ -1,12 +1,11 @@
-const {
-  zipWith, call,
-} = require('ramda');
-
-// TODO: TESTS
+const zipWith = require('ramda/src/zipWith');
+const call = require('ramda/src/call');
 
 /**
  * Applies an array of transform functions to an array of values, with each
  * transform being applied to the value that has the same index.
+ *
+ * TODO: TESTS
  *
  * @signature [a -> b] -> [a] -> [b]
  *

--- a/src/losant/format.js
+++ b/src/losant/format.js
@@ -1,4 +1,4 @@
-const { curryN } = require('ramda');
+const curryN = require('ramda/src/curryN');
 const stringFormat = require('string-format');
 
 /**

--- a/src/losant/fp-throw.js
+++ b/src/losant/fp-throw.js
@@ -1,6 +1,4 @@
-const { is } = require('ramda');
-
-// TODO: TESTS
+const is = require('ramda/src/is');
 
 /**
  * Takes an error and immediately throws it. Useful for throwing an error when
@@ -8,6 +6,8 @@ const { is } = require('ramda');
  * function to throw it. If the given error is not a Error instance then it
  * will be used as the error message and a new Error instance will be created
  * and then thrown.
+ *
+ * TODO: TESTS
  *
  * @signature Error | String -> void
  *

--- a/src/losant/index.js
+++ b/src/losant/index.js
@@ -1,2 +1,3 @@
-const { fromFiles } = require('@rjhilgefort/export-dir');
+const fromFiles = require('@rjhilgefort/export-dir/src/from-files');
+
 module.exports = fromFiles(null, __dirname);

--- a/src/losant/intersect-any.js
+++ b/src/losant/intersect-any.js
@@ -1,7 +1,13 @@
-const {
-  filter, gt, __, compose, unnest, keys, map,
-  unless, equals,
-} = require('ramda');
+const __ = require('ramda/src/__');
+const filter = require('ramda/src/filter');
+const gt = require('ramda/src/gt');
+const compose = require('ramda/src/compose');
+const unnest = require('ramda/src/unnest');
+const keys = require('ramda/src/keys');
+const map = require('ramda/src/map');
+const unless = require('ramda/src/unless');
+const equals = require('ramda/src/equals');
+
 const count = require('./count');
 
 const gt1 = gt(__, 1);
@@ -16,13 +22,14 @@ const parseIntIfPossible =
 /**
  * Finds *any* intersections between any number of lists.
  *
+ * TODO: Handle strings that look like numbers. See tests.
+ *
  * @signature [[String | Number a]] -> [a]
  *
  * @example
  *   intersectAny([[1, 2, 3], [5, 6, 9], [3, 9]])            // => [3, 9]
  *   intersectAny([['foo', 'bar'], ['baz'], ['bar', 'qux']]) // => ['bar']
  */
-// TODO: Handle strings that look like numbers. See tests.
 const intersectAny =
   compose(
     map(parseIntIfPossible),

--- a/src/losant/is-nil-or-empty.js
+++ b/src/losant/is-nil-or-empty.js
@@ -1,6 +1,6 @@
-const {
-  either, isNil, isEmpty,
-} = require('ramda');
+const either = require('ramda/src/either');
+const isNil = require('ramda/src/isNil');
+const isEmpty = require('ramda/src/isEmpty');
 
 /**
  * Checks if a value is null, undefined, or an empty string.

--- a/src/losant/is-not-empty.js
+++ b/src/losant/is-not-empty.js
@@ -1,4 +1,5 @@
-const { complement, isEmpty } = require('ramda');
+const complement = require('ramda/src/complement');
+const isEmpty = require('ramda/src/isEmpty');
 
 /**
  * Returns true if value is non-empty.

--- a/src/losant/is-not-nil.js
+++ b/src/losant/is-not-nil.js
@@ -1,4 +1,5 @@
-const { complement, isNil } = require('ramda');
+const complement = require('ramda/src/complement');
+const isNil = require('ramda/src/isNil');
 
 /**
  * Takes a value and returns true if the value is neither null nor undefined;

--- a/src/losant/is-not.js
+++ b/src/losant/is-not.js
@@ -1,6 +1,5 @@
-const {
-  complement, is,
-} = require('ramda');
+const complement = require('ramda/src/complement');
+const is = require('ramda/src/is');
 
 /**
  * Checks if a value is not of a certain type (i.e. the opposite of `is`).

--- a/src/losant/is-populated-string.js
+++ b/src/losant/is-populated-string.js
@@ -1,4 +1,5 @@
-const { is, allPass } = require('ramda');
+const is = require('ramda/src/is');
+const allPass = require('ramda/src/allPass');
 
 const isNotEmpty = require('./is-not-empty');
 

--- a/src/losant/json-parse-safe.js
+++ b/src/losant/json-parse-safe.js
@@ -1,4 +1,4 @@
-const { pipe } = require('ramda');
+const pipe = require('ramda/src/pipe');
 
 const list = require('./list');
 const tryCatchSafe = require('./try-catch-safe');

--- a/src/losant/key-by-with.js
+++ b/src/losant/key-by-with.js
@@ -1,4 +1,6 @@
-const { curry, reduce } = require('ramda');
+const curry = require('ramda/src/curry');
+const reduce = require('ramda/src/reduce');
+const assoc = require('ramda/src/assoc');
 
 /**
  * A variant of `keyBy` / `indexBy` that accepts getter functions for both the
@@ -15,10 +17,7 @@ const keyByWith = curry((getKey, getValue, list) => {
     const key = getKey(obj);
     const value = getValue(obj);
 
-    return {
-      ...acc,
-      [key]: value,
-    };
+    return assoc(key, value, acc);
   };
 
   return reduce(reducer, {}, list);

--- a/src/losant/list.js
+++ b/src/losant/list.js
@@ -1,8 +1,12 @@
-const { unapply, identity } = require('ramda');
+const unapply = require('ramda/src/unapply');
+const identity = require('ramda/src/identity');
 
-// TODO: TESTS
-// TODO: DOCS
-
-// list :: [*...] -> Array<*>
+/**
+ * TODO: TESTS
+ * TODO: DOCS
+ *
+ * @signature *... -> Array<*>
+ */
 const list = unapply(identity);
+
 module.exports = list;

--- a/src/losant/merge-spec.js
+++ b/src/losant/merge-spec.js
@@ -1,12 +1,17 @@
-const {
-  curry, converge, merge, identity, applySpec,
-} = require('ramda');
+const curry = require('ramda/src/curry');
+const converge = require('ramda/src/converge');
+const merge = require('ramda/src/merge');
+const identity = require('ramda/src/identity');
+const applySpec = require('ramda/src/applySpec');
 
-// TODO: TESTS
-// TODO: DOCS
+/**
+ * TODO: TESTS
+ * TODO: DOCS
+ *
+ * @signature Object a -> Object b -> Object a b
+ */
+const mergeSpec = curry((spec, data) =>
+  converge(merge, [identity, applySpec(spec)])(data)
+);
 
-// mergeSpec :: Object a => Object b -> Object a b
-const mergeSpec = curry((spec, data) => {
-  return converge(merge, [identity, applySpec(spec)])(data);
-});
 module.exports = mergeSpec;

--- a/src/losant/merge-with-arrays.js
+++ b/src/losant/merge-with-arrays.js
@@ -1,4 +1,6 @@
-const { mergeWith, concat, isArray } = require('lodash/fp');
+const mergeWith = require('lodash/fp/mergeWith');
+const concat = require('ramda/src/concat');
+const is = require('ramda/src/is');
 
 /**
  * A merge that also handles arrays.
@@ -23,7 +25,7 @@ const { mergeWith, concat, isArray } = require('lodash/fp');
 const mergeWithArrays =
   mergeWith(
     (x, y) => {
-      if (isArray(x)) { return concat(x, y); }
+      if (is(Array, x)) { return concat(x, y); }
       // return `undefined` so `mergeWith` does default
     }
   );

--- a/src/losant/none-pass.js
+++ b/src/losant/none-pass.js
@@ -1,4 +1,5 @@
-const { complement, anyPass } = require('ramda');
+const complement = require('ramda/src/complement');
+const anyPass = require('ramda/src/anyPass');
 
 /**
  * Takes a list of predicates and returns a predicate that returns true for a

--- a/src/losant/prop-or-strict.js
+++ b/src/losant/prop-or-strict.js
@@ -1,16 +1,20 @@
-const {
-  curry, compose, prop,
-} = require('ramda');
+const curry = require('ramda/src/curry');
+const compose = require('ramda/src/compose');
+const prop = require('ramda/src/prop');
+
 const defaultToStrict = require('./default-to-strict');
 
-// TODO: TESTS
-// TODO: DOCS
-
-// propOrStrict :: * a => String => Object -> a|*
-const propOrStrict = curry((def, key, data) => {
-  return compose(
+/**
+ * TODO: TESTS
+ * TODO: DOCS
+ *
+ * @signature * a -> String -> Object -> a|*
+ */
+const propOrStrict = curry((def, key, data) =>
+  compose(
     defaultToStrict(def),
     prop(key),
-  )(data);
-});
+  )(data)
+);
+
 module.exports = propOrStrict;

--- a/src/losant/replace-all.js
+++ b/src/losant/replace-all.js
@@ -1,6 +1,7 @@
-const {
-  pipe, split, join, curry,
-} = require('ramda');
+const pipe = require('ramda/src/pipe');
+const split = require('ramda/src/split');
+const join = require('ramda/src/join');
+const curry = require('ramda/src/curry');
 
 /**
  * Really, using `R.replace` with regex is fine, but this makes a nice interface.
@@ -15,11 +16,11 @@ const {
  *   );
  *   // foo\nbar\nbaz\n
  */
-const replaceAll = curry((target, replacement, data) => {
-  return pipe(
+const replaceAll = curry((target, replacement, data) =>
+  pipe(
     split(target),
     join(replacement),
-  )(data);
-});
+  )(data)
+);
 
 module.exports = replaceAll;

--- a/src/losant/round.js
+++ b/src/losant/round.js
@@ -1,5 +1,7 @@
-const { compose, curryN, flip } = require('ramda');
-const _ = require('lodash');
+const compose = require('ramda/src/compose');
+const curryN = require('ramda/src/curryN');
+const flip = require('ramda/src/flip');
+const _round = require('lodash/round');
 
 /**
  * Curried FP version of `lodash.round`
@@ -9,6 +11,6 @@ const _ = require('lodash');
  * @signature Number -> Number -> Number
  * @see lodash.round
  */
-const round = compose(flip, curryN(2))(_.round);
+const round = compose(flip, curryN(2))(_round);
 
 module.exports = round;

--- a/src/losant/string-to-boolean.js
+++ b/src/losant/string-to-boolean.js
@@ -1,6 +1,8 @@
-const {
-  pipe, toLower, trim, defaultTo,
-} = require('ramda');
+const pipe = require('ramda/src/pipe');
+const toLower = require('ramda/src/toLower');
+const trim = require('ramda/src/trim');
+const defaultTo = require('ramda/src/defaultTo');
+
 const equalsAny = require('./equals-any');
 
 /**

--- a/src/losant/stringify.js
+++ b/src/losant/stringify.js
@@ -1,4 +1,5 @@
-const { __, curryN } = require('ramda');
+const __ = require('ramda/src/__');
+const curryN = require('ramda/src/curryN');
 
 const stringifyObject = require('stringify-object');
 

--- a/src/losant/test-harness.js
+++ b/src/losant/test-harness.js
@@ -1,6 +1,6 @@
-const {
-  pipe, curry, map,
-} = require('ramda');
+const pipe = require('ramda/src/pipe');
+const curry = require('ramda/src/curry');
+const map = require('ramda/src/map');
 
 const format = require('./format');
 const stringify = require('./stringify');

--- a/src/losant/throttle-leading.js
+++ b/src/losant/throttle-leading.js
@@ -1,3 +1,8 @@
 const throttle = require('./throttle');
 
-module.exports = throttle({ trailing: false });
+/**
+ * @signature Number -> Function -> Function
+ */
+const throttleLeading = throttle({ trailing: false });
+
+module.exports = throttleLeading;

--- a/src/losant/throttle-trailing.js
+++ b/src/losant/throttle-trailing.js
@@ -1,3 +1,8 @@
 const throttle = require('./throttle');
 
-module.exports = throttle({ leading: false });
+/**
+ * @signature Number -> Function -> Function
+ */
+const throttleTrailing = throttle({ leading: false });
+
+module.exports = throttleTrailing;

--- a/src/losant/throttle.js
+++ b/src/losant/throttle.js
@@ -1,5 +1,11 @@
-const { compose, curryN } = require('ramda');
-const { flip } = require('lodash/fp');
-const { throttle } = require('lodash');
+const compose = require('ramda/src/compose');
+const curryN = require('ramda/src/curryN');
+const flip = require('lodash/fp/flip');
+const _throttle = require('lodash/throttle');
 
-module.exports = compose(curryN(3), flip)(throttle);
+/**
+ * @signature Object -> Number -> Function -> Function
+ */
+const throttle = compose(curryN(3), flip)(_throttle);
+
+module.exports = throttle;

--- a/src/losant/thunkify.js
+++ b/src/losant/thunkify.js
@@ -1,4 +1,4 @@
-const { curry } = require('ramda');
+const curry = require('ramda/src/curry');
 
 /**
  * Takes a function and returns a function that takes any number of arguments

--- a/src/losant/trace.js
+++ b/src/losant/trace.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-const { curry } = require('ramda');
+const curry = require('ramda/src/curry');
 
 /**
  * Effectively a curried `console.log` that also returns it's input.

--- a/src/losant/try-catch-safe.js
+++ b/src/losant/try-catch-safe.js
@@ -1,4 +1,4 @@
-const { curry } = require('ramda');
+const curry = require('ramda/src/curry');
 
 /**
  * A safe version of `try/catch` that returns an [error, result] tuple instead

--- a/src/losant/update-key-paths.js
+++ b/src/losant/update-key-paths.js
@@ -1,4 +1,7 @@
-const { pipe, assocPath, adjust, apply } = require('ramda');
+const pipe = require('ramda/src/pipe');
+const assocPath = require('ramda/src/assocPath');
+const adjust = require('ramda/src/adjust');
+const apply = require('ramda/src/apply');
 
 const list = require('./list');
 const ensureArray = require('./ensure-array');

--- a/src/losant/update-keys-with.js
+++ b/src/losant/update-keys-with.js
@@ -1,4 +1,8 @@
-const { curry, prop, propOr, reduce, keys } = require('ramda');
+const curry = require('ramda/src/curry');
+const prop = require('ramda/src/prop');
+const propOr = require('ramda/src/propOr');
+const reduce = require('ramda/src/reduce');
+const keys = require('ramda/src/keys');
 
 /**
  * Updates the keys for an object using the provided function and a map of

--- a/src/losant/update-keys.js
+++ b/src/losant/update-keys.js
@@ -1,4 +1,4 @@
-const { assoc } = require('ramda');
+const assoc = require('ramda/src/assoc');
 
 const updateKeysWith = require('./update-keys-with');
 

--- a/src/losant/upper-camel-case.js
+++ b/src/losant/upper-camel-case.js
@@ -1,5 +1,6 @@
-const { upperFirst, camelCase } = require('lodash/fp');
-const { compose } = require('ramda');
+const compose = require('ramda/src/compose');
+const upperFirst = require('lodash/fp/upperFirst');
+const camelCase = require('lodash/fp/camelCase');
 
 /**
  * Upper-first-camelcase-ify
@@ -11,4 +12,5 @@ const { compose } = require('ramda');
  *   upperCamelCase('foo_bar_baz') // => 'FooBarBaz'
  */
 const upperCamelCase = compose(upperFirst, camelCase);
+
 module.exports = upperCamelCase;

--- a/src/losant/within.js
+++ b/src/losant/within.js
@@ -1,6 +1,12 @@
-const { curry, gt, lt, __, both } = require('ramda');
+const __ = require('ramda/src/__');
+const curry = require('ramda/src/curry');
+const gt = require('ramda/src/gt');
+const lt = require('ramda/src/lt');
+const both = require('ramda/src/both');
 
-// within :: Number -> Number -> Number -> Boolean
+/**
+ * @signature Number -> Number -> Number -> Boolean
+ */
 const within = curry(
   (start, end, value) =>
     both(


### PR DESCRIPTION
Also normalizes styles for documentation & arrow functions