### PR TITLE
Standardize indentation of `@example` blocks

### DIFF
--- a/src/losant/args-to-obj.js
+++ b/src/losant/args-to-obj.js
@@ -10,12 +10,12 @@ const list = require('./list');
  * @signature [k1, k2, k3] -> (a, b, c, d) -> { k1: a, k2: b, k3: c }
  *
  * @example
- *     argsToObj(['foo', 'bar'])(1, 2); // { foo: 1, bar: 2 }
+ *   argsToObj(['foo', 'bar'])(1, 2); // { foo: 1, bar: 2 }
  *
- *     function foo() {
- *       return argsToObj(['a', 'b', 'c'])(arguments);
- *     }
- *     foo(1, 2, 3, 4); // { a: 1, b: 2, c: 3 }
+ *   function foo() {
+ *     return argsToObj(['a', 'b', 'c'])(arguments);
+ *   }
+ *   foo(1, 2, 3, 4); // { a: 1, b: 2, c: 3 }
  */
 const argsToObj = (keys) => pipe(list, zipObj(keys));
 

--- a/src/losant/clamp-positive.js
+++ b/src/losant/clamp-positive.js
@@ -10,12 +10,12 @@ const clamp = require('ramda/src/clamp');
  * @signature Number -> Number
  *
  * @example
- *     clampPositive(-1); // => 0
- *     clampPositive(0); // => 0
- *     clampPositive(20); // => 20
- *     clampPositive(-Infinity); // => 0
- *     clampPositive(Infinity); // => Infinity
- *     clampPositive(NaN); // => NaN
+ *   clampPositive(-1); // => 0
+ *   clampPositive(0); // => 0
+ *   clampPositive(20); // => 20
+ *   clampPositive(-Infinity); // => 0
+ *   clampPositive(Infinity); // => Infinity
+ *   clampPositive(NaN); // => NaN
  */
 const clampPositive = clamp(0, Infinity);
 

--- a/src/losant/contains-all.js
+++ b/src/losant/contains-all.js
@@ -11,7 +11,7 @@ const equals = require('ramda/src/equals');
  * @signature Array<* a> -> Array<* a> -> Boolean
  *
  * @example
- *     containsAll([1, 2, 3], [1, 2, 3, 4, 5]); // => true
+ *   containsAll([1, 2, 3], [1, 2, 3, 4, 5]); // => true
  */
 const containsAll = curry((smaller, larger) =>
   pipe(

--- a/src/losant/evolve-array.js
+++ b/src/losant/evolve-array.js
@@ -10,8 +10,8 @@ const call = require('ramda/src/call');
  * @signature [a -> b] -> [a] -> [b]
  *
  * @example
- *     evolveArray([inc, dec], [10, 20]); // => [11, 19]
- *     evolveArray([add(2), subtract(5), divide(3)], [10, 20, 30]); // => [12, 15, 10]
+ *   evolveArray([inc, dec], [10, 20]); // => [11, 19]
+ *   evolveArray([add(2), subtract(5), divide(3)], [10, 20, 30]); // => [12, 15, 10]
  */
 const evolveArray = zipWith(call);
 

--- a/src/losant/json-parse-safe.js
+++ b/src/losant/json-parse-safe.js
@@ -10,8 +10,8 @@ const tryCatchSafe = require('./try-catch-safe');
  * @signature * -> Array<?SyntaxError, *>
  *
  * @example
- *     const [error, result] = jsonParseSafe('{ "foo": "bar" }'); // => [null, { foo: 'bar' }]
- *     const [error, result] = jsonParseSafe('{'); // => [SyntaxError, null]
+ *   const [error, result] = jsonParseSafe('{ "foo": "bar" }'); // => [null, { foo: 'bar' }]
+ *   const [error, result] = jsonParseSafe('{'); // => [SyntaxError, null]
  */
 const jsonParseSafe = pipe(
   list,

--- a/src/losant/none-pass.js
+++ b/src/losant/none-pass.js
@@ -12,13 +12,13 @@ const anyPass = require('ramda/src/anyPass');
  * @signature [(*... -> Boolean)] -> (*... -> Boolean)
  *
  * @example
- *     const isClub = propEq('suit', '♣');
- *     const isSpade = propEq('suit', '♠');
- *     const isRedCard = nonePass([isClub, isSpade]);
+ *   const isClub = propEq('suit', '♣');
+ *   const isSpade = propEq('suit', '♠');
+ *   const isRedCard = nonePass([isClub, isSpade]);
  *
- *     isRedCard({ rank: '10', suit: '♣' }); //=> false
- *     isRedCard({ rank: 'Q', suit: '♠' }); //=> false
- *     isRedCard({ rank: 'Q', suit: '♦' }); //=> true
+ *   isRedCard({ rank: '10', suit: '♣' }); //=> false
+ *   isRedCard({ rank: 'Q', suit: '♠' }); //=> false
+ *   isRedCard({ rank: 'Q', suit: '♦' }); //=> true
  */
 const nonePass = (predicates) => complement(anyPass(predicates));
 

--- a/src/losant/stringify.js
+++ b/src/losant/stringify.js
@@ -7,12 +7,12 @@ const stringifyObject = require('stringify-object');
  * @signature * -> String
  *
  * @example
- *     stringify(''); // => "''"
- *     stringify(true); // => "true"
- *     stringify(null); // => "null"
- *     stringify([1, 2, 3]); // => "[1, 2, 3]"
- *     stringify({ foo: 'bar' }); // => "{ foo: 'bar' }"
- *     stringify(Symbol('foo')); // => "Symbol(foo)"
+ *   stringify(''); // => "''"
+ *   stringify(true); // => "true"
+ *   stringify(null); // => "null"
+ *   stringify([1, 2, 3]); // => "[1, 2, 3]"
+ *   stringify({ foo: 'bar' }); // => "{ foo: 'bar' }"
+ *   stringify(Symbol('foo')); // => "Symbol(foo)"
  */
 const stringify = curryN(2, stringifyObject)(__, {
   indent: '  ',

--- a/src/losant/thunkify.js
+++ b/src/losant/thunkify.js
@@ -7,9 +7,9 @@ const curry = require('ramda/src/curry');
  * @signature Function -> Function -> Function -> *
  *
  * @example
- *    const logger = thunkify(console.log);
- *    const logFoo = logger('foo');
- *    logFoo(); // => 'foo'
+ *   const logger = thunkify(console.log);
+ *   const logFoo = logger('foo');
+ *   logFoo(); // => 'foo'
  */
 const thunkify = curry((fn, value) => () => fn(value));
 

--- a/src/losant/try-catch-safe.js
+++ b/src/losant/try-catch-safe.js
@@ -7,7 +7,7 @@ const curry = require('ramda/src/curry');
  * @signature Function -> Array<*> -> Array<?Error, *>
  *
  * @example
- *     const [error, result] = tryCatchSafe(someFnThatMightThrow, [arg1, arg2]);
+ *   const [error, result] = tryCatchSafe(someFnThatMightThrow, [arg1, arg2]);
  */
 const tryCatchSafe = curry((tryFn, args) => {
   try {

--- a/src/losant/update-key-paths.js
+++ b/src/losant/update-key-paths.js
@@ -16,7 +16,7 @@ const updateKeysWith = require('./update-keys-with');
  * @signature { a: KeyPath } -> { a: * } -> { b: * }
  *
  * @example
- *     updateKeyPaths({ foo: ['params', 'bar'] }, { foo: 1 }); // => { params: { bar: 1 } }
+ *   updateKeyPaths({ foo: ['params', 'bar'] }, { foo: 1 }); // => { params: { bar: 1 } }
  */
 const updateKeyPaths = updateKeysWith(pipe(
   list,

--- a/src/losant/update-keys.js
+++ b/src/losant/update-keys.js
@@ -11,7 +11,7 @@ const updateKeysWith = require('./update-keys-with');
  * @signature { a: KeyPath } -> { a: * } -> { b: * }
  *
  * @example
- *     updateKeys({ foo: 'bar' }, { foo: 1 }); // => { bar: 1 }
+ *   updateKeys({ foo: 'bar' }, { foo: 1 }); // => { bar: 1 }
  */
 const updateKeys = updateKeysWith(assoc);
 


### PR DESCRIPTION
Most of the`@example` blocks in our function docs were indented by 2 spaces but some were indented by 3 or 4 spaces. Super minor but this fixes that.