### PR TITLE
No NPX

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "yarn": ">=1.3.2"
   },
   "scripts": {
-    "preinstall": "losant-scripts force-yarn 2> /dev/null || npx @losant/scripts force-yarn",
     "reinstall": "rm -rf node_modules && yarn install",
     "lint": "esw *.js src test",
     "lint:fix": "yarn lint --fix",


### PR DESCRIPTION
remove preinstall check, because npx doesn't work on ARM docker images, and really, losant-utils itself doesn't care about using yarn

@rjhilgefort when you merge this, could you go ahead and cut&tag a new version of losant-utils?